### PR TITLE
Update BScroll.vue

### DIFF
--- a/src/lib/BScroll.vue
+++ b/src/lib/BScroll.vue
@@ -133,9 +133,9 @@
       this.pullDownInitTop = -50
     },
     mounted() {
-      const thisWrapper = this.$refs.wrapper
-      thisWrapper.firstElementChild.firstElementChild.style.minHeight = thisWrapper.offsetHeight + 'px'
       this.$nextTick(() => {
+        const thisWrapper = this.$refs.wrapper
+        thisWrapper.firstElementChild.firstElementChild.style.minHeight = thisWrapper.offsetHeight + 'px'
         this.initScroll()
       })
     },


### PR DESCRIPTION
fix: 修复特殊情况下获取不到wrapper的高度